### PR TITLE
Adds a hover title of Lead names

### DIFF
--- a/frontend/src/Leaders.js
+++ b/frontend/src/Leaders.js
@@ -74,12 +74,14 @@ export default class Leaders extends React.Component {
                     <TableBody displayRowCheckbox={false}>
                             {flatten.map(t => (
                                 <TableRow key={`${t.id}`}>
-                                    <TableRowColumn key={`${t.id}`} style={{paddingLeft: `${20*t.parents.length+20}px`}}>
+                                    <TableRowColumn key={`${t.id}`} style={{paddingLeft: `${20*t.parents.length+20}px`}} title={t.name}>
                                         {t.name}
                                     </TableRowColumn>
-                                    {Object.keys(STREAM).map(val => (
-                                        <TableRowColumn style={{opacity: t[val.toLowerCase()+"Lead"] ? 1 : 0.5}} key={`${val}${t.id}`}>{findLeadNameUpwards(t, byId, val.toLowerCase()+"Lead")}</TableRowColumn>
-                                    ))}
+                                    {Object.keys(STREAM).map(val => {
+                                      const leadName = findLeadNameUpwards(t, byId, val.toLowerCase()+"Lead")
+                                      return (
+                                        <TableRowColumn style={{opacity: t[val.toLowerCase()+"Lead"] ? 1 : 0.5}} key={`${val}${t.id}`} title={leadName}>{leadName}</TableRowColumn>
+                                    )})}
                                 </TableRow>
                             ))}
                     </TableBody>


### PR DESCRIPTION
Lots of columns and long names makes it hard to see details.

Adding the hover title to make things visible﻿

![Screenshot 2021-03-15 at 10 00 54](https://user-images.githubusercontent.com/191863/111136427-a6bcf000-8575-11eb-9958-567231caf993.png)
